### PR TITLE
Docs: Align README and makefile with codebase

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ vendor:
 	go mod vendor
 
 build: fmt deps vendor
-	go build -o bin/main cmd/main.go
+	go build -o bin/gsched cmd/main.go
 
 run: fmt deps vendor
 	go run cmd/main.go


### PR DESCRIPTION
This commit updates the README.md and makefile to ensure they accurately reflect the current state and behavior of the application.

Key changes:

- Updated Go version in README to 1.21 to match go.mod.
- Aligned binary name to `bin/gsched` in both README and makefile.
- Clarified in README that `make run` defaults to scheduler and does not take role flags.
- Significantly updated the "Features" section of the README to accurately describe that the scheduler role executes tasks locally *before* dispatching the original job details to Kafka. This corrects a previous inaccuracy where the README implied schedulers only dispatch and workers only execute.
- Synchronized `cronTime` examples in the README's `schedule.json` snippet with the actual examples in `schedule/schedule.json` (now `* * * * *`).
- Marked the "Implement Consumer Workers" TODO item as complete in README, as this functionality is present in `worker/worker.go`.